### PR TITLE
Create users endpoint. Additional validation on login/logout

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,6 +13,22 @@ class ApplicationController < ActionController::API
     render json: { errors: ['Not Authenticated'] }, status: :unauthroized
   end
 
+  def payload(user)
+    return nil unless user && user.id
+    {
+      auth_token: JsonWebToken.encode(user_id: user.id),
+      user: { id: user.id, name: user.name, email: user.email }
+    }
+  end
+
+  def signed_in?
+    render json: { 'logged_in': false } if session[:jwt].nil?
+  end
+
+  def not_signed_in?
+    render json: { 'logged_in': true } unless session[:jwt].nil?
+  end
+
   private
 
   def http_token

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -1,4 +1,7 @@
 class AuthController < ApplicationController
+  before_action :not_signed_in?, only: :authenticate_user
+  before_action :signed_in?, only: :invalidate_user
+
   def authenticate_user
     user = User.find_by_email(params[:email].downcase)
     if user && user.authenticate(params[:password])
@@ -19,15 +22,5 @@ class AuthController < ApplicationController
 
   def signed_in
     render json: { 'logged_in': !session[:jwt].nil? }
-  end
-
-  private
-
-  def payload(user)
-    return nil unless user && user.id
-    {
-      auth_token: JsonWebToken.encode(user_id: user.id),
-      user: { id: user.id, name: user.name, email: user.email }
-    }
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,22 @@
+class UsersController < ApplicationController
+  before_action :not_signed_in?, only: :create
+
+  def create
+    user = User.new(user_params)
+    if user.save
+      session[:jwt] = {
+        value: payload(user),
+        expires: 1.day.from_now
+      }
+      render json: { 'logged_in': true }
+    else
+      render json: { errors: user.errors.full_messages }
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name, :email, :password, :password_confirmation)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,10 @@ Rails.application.routes.draw do
       match '/logout' => 'auth#invalidate_user', via: [:post]
       match '/signed_in' => 'auth#signed_in', via: [:get]
     end
+
+    scope '/user' do
+      match '/create' => 'users#create', via: [:post]
+    end
   end
   #  Send static files
   match '/*path' => 'static#base', via: [:get]


### PR DESCRIPTION
Related Issue #21 

Changes:
- Endpoint for creating users at /api/user/create
- Can't login if already logged in
- Can't logout if not logged in
