### PR TITLE
Update rubocop configs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@
 
 AllCops:
   Exclude:
+    - 'bin/**/*'
     - 'client/**/*'
     - 'tmp/**/*'
     - 'vendor/**/*'
@@ -10,7 +11,13 @@ AllCops:
   TargetRubyVersion: 2.2
 
 Metrics/LineLength:
-  Enabled: false
+  Max: 100
+
+Metrics/AbcSize:
+  Max: 25
+
+Metrics/MethodLength:
+  Max: 20
 
 Style/Documentation:
   Enabled: false

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,5 +1,7 @@
 class StaticController < ApplicationController
   def base
-    send_data File.open("#{Rails.root}/client/dist/index.html"), type: 'text/html; charset=utf-8', disposition: 'inline'
+    send_data File.open("#{Rails.root}/client/dist/index.html"),
+              type: 'text/html; charset=utf-8',
+              disposition: 'inline'
   end
 end

--- a/config/initializers/backtrace_silencers.rb
+++ b/config/initializers/backtrace_silencers.rb
@@ -1,7 +1,9 @@
 # Be sure to restart your server when you modify this file.
 
-# You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.
+# You can add backtrace silencers for libraries that you're
+# using but don't wish to see in your backtraces.
 # Rails.backtrace_cleaner.add_silencer { |line| line =~ /my_noisy_library/ }
 
-# You can also remove all the silencers if you're trying to debug a problem that might stem from framework code.
+# You can also remove all the silencers if you're trying to
+# debug a problem that might stem from framework code.
 # Rails.backtrace_cleaner.remove_silencers!

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,6 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
+# This file should contain all the record creation needed to seed the
+# database with its default values. The data can then be loaded with the
+# rails db:seed command (or created alongside the database with db:setup).
 #
 # Examples:
 #


### PR DESCRIPTION
Related Issue #55 

Changes:
- Line length set to 100 characters
- Method length set to 20 characters
- ABC size set to 25
