### PR TITLE
Session updates and other minor fixes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,10 +2,17 @@ class ApplicationController < ActionController::API
   protected
 
   def signed_in?
-    render json: { errors: ['Not Authenticated'] }, status: :unauthorized if session[:user_id].nil?
+    return if session_not_expired?
+    render json: { errors: ['Not Authenticated'] }, status: :unauthorized
   end
 
   def not_signed_in?
-    render json: { 'logged_in': true } unless session[:user_id].nil?
+    return unless session_not_expired?
+    render json: { 'logged_in': true }
+  end
+
+  def session_not_expired?
+    user_session = session[:user_id]
+    user_session && user_session[:expires] >= 1.day.ago
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,10 +2,10 @@ class ApplicationController < ActionController::API
   protected
 
   def signed_in?
-    render json: { errors: ['Not Authenticated'] }, status: :unauthorized if session[:user].nil?
+    render json: { errors: ['Not Authenticated'] }, status: :unauthorized if session[:user_id].nil?
   end
 
   def not_signed_in?
-    render json: { 'logged_in': true } unless session[:user].nil?
+    render json: { 'logged_in': true } unless session[:user_id].nil?
   end
 end

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -15,11 +15,11 @@ class AuthController < ApplicationController
   def login
     user = User.find_by_email(params[:email].downcase)
     if user && user.authenticate(params[:password])
-      session[:user] = {
-        value: user.as_json(only: [:id, :name, :email, :birthday]),
+      session[:user_id] = {
+        value: user.id,
         expires: 1.day.from_now
       }
-      render json: { 'logged_in': true, user: session[:user] }
+      render json: { 'logged_in': true, user: user.as_json(only: [:id, :name, :email, :birthday]) }
     else
       render json: { errors: ['Invalid Username/Password'] }, status: :unauthorized # 401
     end
@@ -32,7 +32,7 @@ class AuthController < ApplicationController
   #   Code: 200
   #   Content: { 'logged_in': false }
   def logout
-    session.delete(:user)
+    session.delete(:user_id)
     render json: { 'logged_in': false }
   end
 
@@ -45,8 +45,9 @@ class AuthController < ApplicationController
   #   (2) Code: 200
   #   Content: { 'logged_in': false }
   def signed_in
-    if !session[:user].nil?
-      render json: { 'logged_in': true, user: session[:user] }
+    user_session = session[:user_id]
+    if user_session && user_session[:expires] >= 1.day.ago
+      render json: { 'logged_in': true, user_id: user_session[:value] }
     else
       render json: { 'logged_in': false }, status: :unauthorized # 401
     end

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -41,13 +41,12 @@ class AuthController < ApplicationController
   #   none
   # Success response:
   #   (1) Code: 200
-  #   Content: { 'logged_in': true, user: { id: int, name: string, email: string, birthday: date } }
+  #   Content: { 'logged_in': true, user_id: int }
   #   (2) Code: 200
   #   Content: { 'logged_in': false }
   def signed_in
-    user_session = session[:user_id]
-    if user_session && user_session[:expires] >= 1.day.ago
-      render json: { 'logged_in': true, user_id: user_session[:value] }
+    if session_not_expired?
+      render json: { 'logged_in': true, user_id: session[:user_id][:value] }
     else
       render json: { 'logged_in': false }, status: :unauthorized # 401
     end

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -1,5 +1,6 @@
 class LessonsController < ApplicationController
   # { lesson } = { 'id': int, 'title': '', 'wordinfo': { wordinfo } }
+  before_action :signed_in?
 
   # GET /api/lesson/all
   # Desc: return all lessons created by current user

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,7 +6,6 @@ class UsersController < ApplicationController
   #   name (string)
   #   email (string)
   #   password (string)
-  #   password_confirmation (string)
   #   birthday (isodate)
   # Success response:
   #   Code: 200
@@ -19,11 +18,11 @@ class UsersController < ApplicationController
   def create
     user = User.new(user_params)
     if user.save
-      session[:user] = {
-        value: user.as_json(only: [:id, :name, :email, :birthday]),
+      session[:user_id] = {
+        value: user.id,
         expires: 1.day.from_now
       }
-      render json: { 'logged_in': true, user: session[:user] }
+      render json: { 'logged_in': true, user: user.as_json(only: [:id, :name, :email, :birthday]) }
     elsif user.errors['email'] && user.errors['email'].include?('has already been taken')
       render json: { errors: user.errors }, status: :conflict # 409
     else
@@ -52,6 +51,6 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:name, :email, :password, :password_confirmation, :birthday)
+    params.require(:user).permit(:name, :email, :password, :birthday)
   end
 end

--- a/app/controllers/wordinfo_controller.rb
+++ b/app/controllers/wordinfo_controller.rb
@@ -1,6 +1,7 @@
 class WordinfoController < ApplicationController
   # { wordinfo } = { 'id': int, 'word': '', 'definition': '', 'roots': [''], 'forms': [{wordinfo}],
   #                  'synonyms': [''], 'antonyms': [''], sentences: [''] }
+  before_action :signed_in?
 
   # GET /api/wordinfo/all
   # Desc: return all word infos created by current user

--- a/db/migrate/20161014171914_add_default_value_to_lesson_title.rb
+++ b/db/migrate/20161014171914_add_default_value_to_lesson_title.rb
@@ -1,0 +1,5 @@
+class AddDefaultValueToLessonTitle < ActiveRecord::Migration[5.0]
+  def change
+    change_column_default :lessons, :title, 'Untitled'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161012045020) do
+ActiveRecord::Schema.define(version: 20161014171914) do
 
   create_table "antonyms", force: :cascade do |t|
     t.string   "word"
@@ -39,10 +39,10 @@ ActiveRecord::Schema.define(version: 20161012045020) do
   end
 
   create_table "lessons", force: :cascade do |t|
-    t.string   "title"
+    t.string   "title",         default: "Untitled"
     t.integer  "instructor_id"
-    t.datetime "created_at",    null: false
-    t.datetime "updated_at",    null: false
+    t.datetime "created_at",                         null: false
+    t.datetime "updated_at",                         null: false
     t.index ["instructor_id"], name: "index_lessons_on_instructor_id"
   end
 


### PR DESCRIPTION
Changes:
- Only user id is stored in session
- Check if the session is expired
- Remove password confirmation from user creation
- Lesson title defaults to 'Untitled'
- Auth required on word and lesson end points

Breaking Changes:
- `/api/auth/signed_in` returns user id instead of user object
