### PR TITLE
Lesson types moved into datatypes

### DIFF
--- a/client/src/actions/lesson.ts
+++ b/client/src/actions/lesson.ts
@@ -4,7 +4,7 @@ import {
     throttle
 } from './util';
 import { push } from 'react-router-redux';
-import { Lesson } from '../reducers/lessonReducer';
+import { Lesson } from 'datatypes/lessonTypes';
 
 export interface CreateLessonPending {
     type: 'create_lesson_pending';

--- a/client/src/components/Home.tsx
+++ b/client/src/components/Home.tsx
@@ -6,7 +6,9 @@ import {
 } from 'material-ui';
 
 import ContentAdd from 'material-ui/svg-icons/content/add';
-import {Lesson} from '../reducers/lessonReducer';
+import {
+    Lesson
+} from 'datatypes/lessonTypes';
 import Page from './util/Page';
 import * as React from 'react';
 

--- a/client/src/components/Lesson/LessonCreator.tsx
+++ b/client/src/components/Lesson/LessonCreator.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import WordCreator from './WordCreator';
 import Page from '../util/Page';
 import BindingComponent from '../util/BindingComponent';
-import {Lesson} from '../../reducers/lessonReducer';
+import { Lesson } from 'datatypes/lessonTypes';
 import {
     TextField,
 } from 'material-ui';

--- a/client/src/components/Lesson/WordCreator.tsx
+++ b/client/src/components/Lesson/WordCreator.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {WordInput} from './WordInput';
-import {WordInfo} from '../../reducers/lessonReducer';
+import { WordInfo } from 'datatypes/lessonTypes';
 import { List, ListItem, Subheader } from 'material-ui';
 export interface WordCreatorProps {
     name?: string;

--- a/client/src/components/Lesson/WordInput.tsx
+++ b/client/src/components/Lesson/WordInput.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {
     TextField,
 } from 'material-ui';
-import {WordInfo} from '../../reducers/lessonReducer';
+import { WordInfo } from 'datatypes/lessonTypes';
 
 export interface WordCreatorProps {
     value?: WordInfo;

--- a/client/src/containers/LessonCreatorContainer.tsx
+++ b/client/src/containers/LessonCreatorContainer.tsx
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import LessonCreator from '../components/Lesson/LessonCreator';
-import { Lesson } from '../reducers/lessonReducer';
+import { Lesson } from 'datatypes/lessonTypes';
 import { State } from '../reducers/index';
 import { saveLesson, loadLesson } from '../actions/lesson';
 

--- a/client/src/datatypes/lessonTypes.ts
+++ b/client/src/datatypes/lessonTypes.ts
@@ -1,0 +1,14 @@
+export interface WordInfo {
+    id?: number;
+    word: string;
+}
+
+export interface Lesson {
+    id: number;
+    title: string;
+    word_infos: WordInfo[];
+}
+
+export type LessonState = {
+    [id: number]: Lesson
+}

--- a/client/src/reducers/index.ts
+++ b/client/src/reducers/index.ts
@@ -1,8 +1,9 @@
 import { SessionState, sessionReducer } from './sessionReducer';
-import { LessonState, lessonReducer } from './lessonReducer';
+import { lessonReducer } from './lessonReducer';
 import { RegistrationState, registrationReducer } from './registrationReducer';
 import { combineReducers } from 'redux';
 import { routerReducer } from 'react-router-redux';
+import { LessonState } from 'datatypes/lessonTypes';
 
 export interface State {
     session: SessionState;

--- a/client/src/reducers/lessonReducer.ts
+++ b/client/src/reducers/lessonReducer.ts
@@ -1,15 +1,20 @@
-export interface WordInfo {
-    id?: number;
-    word: string;
-}
+import {
+    LessonState,
+    Lesson
+} from 'datatypes/lessonTypes';
 
-export interface Lesson {
-    id: number;
-    title: string;
-    word_infos: WordInfo[];
-}
+// export interface WordInfo {
+//     id?: number;
+//     word: string;
+// }
 
-export type LessonState = {[id: number]: Lesson};
+// export interface Lesson {
+//     id: number;
+//     title: string;
+//     word_infos: WordInfo[];
+// }
+
+// export type LessonState = {[id: number]: Lesson};
 
 export const lessonReducer = (state: LessonState, action: any): LessonState => {
     if (state === undefined) return {};

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -11,7 +11,8 @@
         "sourceMap": true,
         "jsx": "react",
         "lib": ["dom", "es6", "es2015.promise"],
-        "types": ["whatwg-fetch", "material-ui", "history"]
+        "types": ["whatwg-fetch", "material-ui", "history"],
+        "baseUrl": "src"
     },
     "include": [
         "src/**/*.{tsx,ts}"

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -13,6 +13,7 @@ module.exports = {
     devtool: "source-map",
 
     resolve: {
+        modulesDirectories: ["node_modules", "src"],
         // Add '.ts' and '.tsx' as resolvable extensions.
         extensions: ["", ".webpack.js", ".web.js", ".ts", ".tsx", ".js"]
     },
@@ -46,7 +47,9 @@ module.exports = {
     },
 
     sassLoader: {
-        includePaths: [path.resolve(__dirname, "./styles")]
+        includePaths: [
+            path.resolve(__dirname, "./styles")
+        ]
     },
 
     plugins: [


### PR DESCRIPTION
Related Issue #90 and #91 

Changes:
- Types for lessons have been moved into datatypes
- Folders in src are now root requires

Breaking Changes:
- vscode doesn't recognize the root require change, but it works in the build.

