### PR TITLE
Change synonyms and antonyms to return as array of strings

### DIFF
--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -6,7 +6,7 @@ class Lesson < ApplicationRecord
   validates :title, length: { maximum: 255 }
 
   def as_json(options = {})
-    super(options.merge(
+    lesson = super(options.merge(
       include:
         { wordinfos: {
           include: [
@@ -20,5 +20,10 @@ class Lesson < ApplicationRecord
         } },
       except: [:owner_id, :created_at, :updated_at]
     ))
+    lesson['wordinfos'].each do |wordinfo|
+      wordinfo['synonyms'].map! { |synonym| synonym['word'] }
+      wordinfo['antonyms'].map! { |antonym| antonym['word'] }
+    end
+    lesson
   end
 end

--- a/app/models/wordinfo.rb
+++ b/app/models/wordinfo.rb
@@ -15,7 +15,7 @@ class Wordinfo < ApplicationRecord
   validates_uniqueness_of :word, scope: :lesson, case_sensitive: false
 
   def as_json(options = {})
-    super(options.merge(
+    wordinfos = super(options.merge(
       include: [
         { roots: { only: [:word] } },
         { forms: { only: [:word, :part_of_speech] } },
@@ -25,5 +25,8 @@ class Wordinfo < ApplicationRecord
       ],
       except: [:id, :user_id, :lesson_id, :created_at, :updated_at]
     ))
+    wordinfos['synonyms'].map! { |synonym| synonym['word'] }
+    wordinfos['antonyms'].map! { |antonym| antonym['word'] }
+    wordinfos
   end
 end

--- a/test/controllers/lessons_controller_test.rb
+++ b/test/controllers/lessons_controller_test.rb
@@ -64,14 +64,6 @@ class LessonsControllerTest < ActionController::TestCase
   test 'PATCH /api/lesson/:id bad request (wordinfo word blank)' do
     login_as_testuser
     lesson = lessons(:english101).as_json
-    lesson['wordinfos'].each do |wordinfo|
-      wordinfo.delete('id')
-      wordinfo['roots'].each { |root| root.delete('id') }
-      wordinfo['forms'].each { |form| form.delete('id') }
-      wordinfo['synonyms'].each { |synonym| synonym.delete('id') }
-      wordinfo['antonyms'].each { |antonym| antonym.delete('id') }
-      wordinfo['sentences'].each { |sentence| sentence.delete('id') }
-    end
     lesson['wordinfos'][0]['word'] = ''
     patch :update, params: { id: lesson['id'], lesson: lesson }
     assert_response :bad_request
@@ -136,12 +128,8 @@ class LessonsControllerTest < ActionController::TestCase
     login_as_testuser
     lesson = lessons(:english101).as_json
     lesson['wordinfos'].each do |wordinfo|
-      wordinfo.delete('id')
-      wordinfo['roots'].each { |root| root.delete('id') }
-      wordinfo['forms'].each { |form| form.delete('id') }
-      wordinfo['synonyms'].each { |synonym| synonym.delete('id') }
-      wordinfo['antonyms'].each { |antonym| antonym.delete('id') }
-      wordinfo['sentences'].each { |sentence| sentence.delete('id') }
+      wordinfo['synonyms'].map! { |synonym| { word: synonym } }
+      wordinfo['antonyms'].map! { |antonym| { word: antonym } }
     end
     patch :update, params: { id: lesson['id'], lesson: lesson }
     assert_response :ok

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -42,8 +42,8 @@ module ActiveSupport
             part_of_speech: '',
             roots: [{ word: 'prob' }],
             forms: [{ word: 'probable', part_of_speech: '' }],
-            synonyms: [{ word: 'likely' }],
-            antonyms: [{ word: 'unlikely' }],
+            synonyms: ['likely'],
+            antonyms: ['unlikely'],
             sentences: [{ context_sentence: 'This is probably the best test ever' }]
           }
         ]


### PR DESCRIPTION
Changes:
- Synonyms and antonyms return as arrays of strings