### PR TITLE
One transaction for lesson update

### DIFF
--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -74,9 +74,16 @@ class LessonsController < ApplicationController
       render json: { 'errors': errors }, status: :bad_request # 400
       return
     end
-    Wordinfo.where(id: lesson.wordinfo_ids).destroy_all
-    lesson.attributes = lesson_params
-    unless lesson.save
+    lesson_saved = true
+    ActiveRecord::Base.transaction do
+      Wordinfo.where(id: lesson.wordinfo_ids).destroy_all
+      lesson.attributes = lesson_params
+      unless lesson.save
+        lesson_saved = false
+        raise ActiveRecord::Rollback
+      end
+    end
+    unless lesson_saved
       render json: { 'errors': lesson.errors }, status: :bad_request # 400
       return
     end

--- a/test/controllers/lessons_controller_test.rb
+++ b/test/controllers/lessons_controller_test.rb
@@ -68,6 +68,8 @@ class LessonsControllerTest < ActionController::TestCase
     patch :update, params: { id: lesson['id'], lesson: lesson }
     assert_response :bad_request
     assert_json_match({ errors: { 'wordinfos.word': ['can\'t be blank'] } }, @response.body)
+    lesson = lessons(:english101)
+    assert_not_empty lesson.wordinfos
   end
 
   test 'PATCH /api/lesson/:id multiple wordinfo with same word ' do
@@ -83,6 +85,7 @@ class LessonsControllerTest < ActionController::TestCase
     patch :update, params: { id: lesson.id, lesson: updated_lesson }
     assert_response :bad_request
     assert_json_match({ errors: { 'wordinfos.word': ['has already been taken'] } }, @response.body)
+    assert_not_empty lesson.reload.wordinfos
   end
 
   test 'PATCH /api/lesson/:id wordinfo and synonym with same word' do
@@ -101,6 +104,7 @@ class LessonsControllerTest < ActionController::TestCase
     assert_response :bad_request
     pattern = { errors: { 'wordinfos.synonyms.word': ['synonym cannot be the same word'] } }
     assert_json_match pattern, @response.body
+    assert_not_empty lesson.reload.wordinfos
   end
 
   test 'PATCH /api/lesson/:id two synonyms with same word in one wordinfo' do
@@ -119,6 +123,7 @@ class LessonsControllerTest < ActionController::TestCase
     assert_response :bad_request
     pattern = { errors: { 'wordinfos.synonyms.word': ['has already been taken'] } }
     assert_json_match pattern, @response.body
+    assert_not_empty lesson.reload.wordinfos
   end
 
   test 'PATCH /api/lesson/:id success' do
@@ -127,6 +132,8 @@ class LessonsControllerTest < ActionController::TestCase
     patch :update, params: { id: lesson['id'], lesson: lesson }
     assert_response :ok
     assert_json_match lesson_pattern, @response.body
+    lesson = lessons(:english101)
+    assert_not_empty lesson.wordinfos
   end
 
   test 'DELETE /api/lesson/:id unauthorized' do


### PR DESCRIPTION
Related Issue #132 

Changes:
- Rollback deleting a lesson's wordinfos if lesson update fails
- Assert that the wordinfos list of a lesson is not empty in the tests