### PR TITLE
Submit answer endpoint

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,0 +1,21 @@
+class QuestionsController < ApplicationController
+  before_action :signed_in?
+
+  # POST /api/question/:id/submit_answer
+  # Desc: return true/false if answer provided is correct
+  # Request body params:
+  #   value
+  # Success response:
+  #   Code: 200
+  #   Content: { true/false }
+  # Error response:
+  #   (1) Code: 401
+  #   Content: { errors: ['Unauthorized'], error_message: 'Unauthorized' }
+  #   (2) Code: 404
+  #   Content: { errors: ['Couldn't find Question with 'id'=int'],
+  #              error_message: 'Question could not be found' }
+  def submit_answer
+    option = Option.find_by_question_id_and_value!(params[:id], params[:value])
+    render json: option.is_correct
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,8 @@ Rails.application.routes.draw do
         match '/:p_id' => 'practices#show', via: [:get]
       end
     end
+
+    match '/question/:id/submit_answer' => 'questions#submit_answer', via: [:post]
   end
   #  Send static files
   match '/*path' => 'static#base', via: [:get]

--- a/test/controllers/questions_controller_test.rb
+++ b/test/controllers/questions_controller_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+class QuestionsControllerTest < ActionController::TestCase
+  test 'POST /api/question/:id/submit_answer/ unauthorized' do
+    post :submit_answer, params: { id: 1 }
+    assert_response :unauthorized
+    error_response = { errors: ['Unauthorized'], error_message: 'Unauthorized' }
+    assert_json_match error_response, @response.body
+  end
+
+  test 'POST /api/question/:id/submit_answer/ option not found' do
+    login_as_testuser
+    post :submit_answer, params: { id: 1, value: 'test' }
+    assert_response :not_found
+    error_response = { errors: ['Couldn\'t find Option'],
+                       error_message: 'Option could not be found' }
+    assert_json_match error_response, @response.body
+  end
+
+  test 'POST /api/question/:id/submit_answer/ value incorrect' do
+    login_as_testuser
+    params = { id: options(:probably_synonym_option2).question_id, value: 'unlikely' }
+    post :submit_answer, params: params
+    assert_response :ok
+    assert_equal 'false', @response.body
+  end
+
+  test 'POST /api/question/:id/submit_answer/ value correct' do
+    login_as_testuser
+    params = { id: options(:probably_synonym_option1).question_id, value: 'likely' }
+    post :submit_answer, params: params
+    assert_response :ok
+    assert @response.body
+  end
+end

--- a/test/controllers/routes_test.rb
+++ b/test/controllers/routes_test.rb
@@ -22,6 +22,9 @@ class RoutesTest < ActionController::TestCase
   should route(:post, '/api/lesson/1/practice').to('practices#create', id: 1)
   should route(:get, '/api/lesson/1/practice/1').to('practices#show', id: 1, p_id: 1)
 
+  # question routes
+  should route(:post, '/api/question/1/submit_answer').to('questions#submit_answer', id: 1)
+
   # static files
   should route(:get, '/a').to('static#base', path: 'a')
 end


### PR DESCRIPTION
Related Issue #150 

Changes:
- `POST` `{ value: '' }` to `/api/question/:id/submit_answer`
- Returns `{ true }` or `{ false }`
- Tests