### PR TITLE
Remove is_correct from options array in a practice

### DIFF
--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -1,5 +1,17 @@
 class LessonsController < ApplicationController
-  # { lesson } = { id: int, title: '', wordinfos: [{ wordinfo }] }
+  # { lesson } = {
+  #   id: int,
+  #   title: '',
+  #   wordinfos: [{
+  #     word: '',
+  #     definition: '',
+  #     part_of_speech: '',
+  #     roots: [{ root: '', meaning: '' }],
+  #     forms: [{ word: '', part_of_speech: '' }],
+  #     synonyms: [''],
+  #     antonyms: [''],
+  #     sentences: [{ context_sentence: '' }]
+  #   } }] }
   before_action :signed_in?
 
   # GET /api/lesson

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -6,7 +6,7 @@ class PracticesController < ApplicationController
   #     id: int,
   #     type: '',
   #     prompts: [''],
-  #     options: [{ value: '', is_correct: boolean }]
+  #     options: ['']
   #   }] }
   before_action :signed_in?
 

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -7,7 +7,7 @@ class QuestionsController < ApplicationController
   #   value
   # Success response:
   #   Code: 200
-  #   Content: { true/false }
+  #   Content: true/false
   # Error response:
   #   (1) Code: 401
   #   Content: { errors: ['Unauthorized'], error_message: 'Unauthorized' }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -35,7 +35,7 @@ class UsersController < ApplicationController
   #   email (string)
   # Success response:
   #   Code: 200
-  #   Content: { true/false }
+  #   Content: true/false
   # Error response:
   #   (1) Code: 400
   #   Content: { errors: ['Email not provided'] }

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -12,7 +12,7 @@ class Practice < ApplicationRecord
         questions: {
           include: [
             { prompts: { only: [:text] } },
-            { options: { only: [:value, :is_correct] } }
+            { options: { only: [:value] } }
           ],
           except: [:practice_id, :created_at, :updated_at]
         }
@@ -21,6 +21,7 @@ class Practice < ApplicationRecord
     ))
     practice['questions'].each do |question|
       question['prompts'].map! { |prompt| prompt['text'] }
+      question['options'].map! { |option| option['value'] }
     end
     practice
   end

--- a/test/controllers/practices_controller_test.rb
+++ b/test/controllers/practices_controller_test.rb
@@ -80,7 +80,7 @@ class PracticesControllerTest < ActionController::TestCase
         id: 784075758,
         type: 'fitb',
         prompts: ['This is probably the best test ever'],
-        options: [{ value: 'probably', is_correct: true }]
+        options: ['probably']
       }]
     }
     assert_response :ok

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -60,12 +60,7 @@ module ActiveSupport
             id: 784075757,
             type: 'mc',
             prompts: ['What is the synonym of probably?'],
-            options: [
-              { value: 'likely', is_correct: true },
-              { value: 'unlikely', is_correct: false },
-              { value: 'uncertain', is_correct: false },
-              { value: 'questionable', is_correct: false }
-            ]
+            options: %w(likely unlikely uncertain questionable)
           }
         ]
       }


### PR DESCRIPTION
Changes:
- Remove `is_correct` from options array when returning practices
- Updated comments

Breaking Changes:
- `options` in a question changed to array of values (`[{ value: '', is_correct: boolean }]` to `['']`)
