### PR TITLE
Unique practice types for a lesson

### DIFF
--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -5,6 +5,7 @@ class Practice < ApplicationRecord
   accepts_nested_attributes_for :questions
   enum type: { definition: 0, synonym: 1, root: 2, sentence: 3 }
   validates :type, presence: true
+  validates_uniqueness_of :type, scope: :lesson
 
   def as_json(options = {})
     practice = super(options.merge(

--- a/test/models/practice_test.rb
+++ b/test/models/practice_test.rb
@@ -7,6 +7,11 @@ class PracticeTest < ActiveSupport::TestCase
   should define_enum_for(:type).with([:definition, :synonym, :root, :sentence])
   should validate_presence_of(:type)
 
+  test 'validates uniqueness of type' do
+    practice = Practice.create(lesson: lessons(:english101), type: 'synonym')
+    assert_includes practice.errors.full_messages, 'Type has already been taken'
+  end
+
   test 'practice as json' do
     practice = practices(:synonym_mc)
     assert_json_match practice_pattern, practice.as_json

--- a/test/models/wordinfo_test.rb
+++ b/test/models/wordinfo_test.rb
@@ -17,7 +17,8 @@ class WordinfoTest < ActiveSupport::TestCase
   should validate_length_of(:word).is_at_most(255)
 
   test 'validates uniqueness of word' do
-    assert true
+    wordinfo = Wordinfo.create(word: 'Probably', lesson: lessons(:english101))
+    assert_includes wordinfo.errors.full_messages, 'Word has already been taken'
   end
 
   test 'wordinfo as json' do


### PR DESCRIPTION
Related Issue #174 

Changes:
- Lessons can only have one of each practice type
- Practice uniqueness test
- Add missing wordinfo uniqueness test