### PR TITLE
Add more validations in question generation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,10 +14,13 @@ Metrics/LineLength:
   Max: 100
 
 Metrics/AbcSize:
-  Max: 25
+  Max: 35
 
 Metrics/MethodLength:
-  Max: 30
+  Max: 35
+
+Metrics/CyclomaticComplexity:
+  Max: 8
 
 Metrics/ClassLength:
   Enabled: false

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -61,32 +61,48 @@ class PracticesController < ApplicationController
   #   Content: { errors: { type: ["'' is not a valid type"] } }
   #   (4) Code: 409
   #   Content: {
-  #     errors: ['There are not enough words in this practice to generate a practice'],
-  #     error_message: 'There are not enough words in this practice to generate a practice'
+  #     errors: ['There are not enough words in this lesson to generate a practice'],
+  #     error_message: 'There are not enough words in this lesson to generate a practice'
   #   }
   def create
     lesson = Lesson.find(params[:id])
     type = params[:type]
-    begin
-      practice = Practice.create(lesson: lesson, type: type)
-    rescue ArgumentError => error
-      render json: { errors: { type: [error.message] } }, status: :bad_request # 400
-      return
+    json_rendered = false
+    practice = nil
+    # rollback practice creation if there's an error creating the practice or generating questions
+    ActiveRecord::Base.transaction do
+      begin
+        practice = Practice.create(lesson: lesson, type: type)
+      rescue ArgumentError => error
+        render json: { errors: { type: [error.message] } }, status: :bad_request # 400
+        json_rendered = true
+        raise ActiveRecord::Rollback
+      end
+      # catch duplicate practice error
+      unless practice.errors.empty?
+        render json: { errors: practice.errors }, status: :bad_request # 400
+        json_rendered = true
+        raise ActiveRecord::Rollback
+      end
+
+      # question generation
+      questions_attributes = case type
+                             when 'sentence' then generate_sentence_questions lesson
+                             when 'definition' then generate_definition_questions lesson
+                             when 'synonym' then generate_synonym_questions lesson
+                             end
+      # question generation errors
+      if questions_attributes[0].key?(:error_message)
+        message = questions_attributes[0][:error_message]
+        render json: { errors: [message], error_message: message }, status: :conflict # 409
+        json_rendered = true
+        raise ActiveRecord::Rollback
+      end
+      # save questions if no errors
+      practice.attributes = { questions_attributes: questions_attributes }
+      practice.save
     end
-    questions_attributes = case type
-                           when 'sentence' then generate_sentence_questions lesson
-                           when 'definition' then generate_definition_questions lesson
-                           when 'synonym' then generate_synonym_questions lesson
-                           end
-    if questions_attributes.nil?
-      error_message = 'There are not enough words in this practice to generate a practice'
-      render json: { errors: [error_message], error_message: error_message },
-             status: :conflict # 409
-      return
-    end
-    practice.attributes = { questions_attributes: questions_attributes }
-    practice.save
-    render json: practice.reload
+    render json: practice.reload unless json_rendered
   end
 
   # DELETE /api/practice/:id
@@ -113,6 +129,9 @@ class PracticesController < ApplicationController
   def generate_sentence_questions(lesson)
     questions_attributes = []
     lesson.wordinfos.each do |wordinfo|
+      if wordinfo.sentences.empty?
+        return [{ error_message: "#{wordinfo.word} does not have any context sentences" }]
+      end
       sentence = wordinfo.sentences.first.context_sentence
       words = wordinfo.forms.map(&:word)
       words << wordinfo.word
@@ -129,10 +148,17 @@ class PracticesController < ApplicationController
   end
 
   def generate_definition_questions(lesson)
-    return nil if lesson.wordinfos.length < 4
+    if lesson.wordinfos.length < 4
+      return [{
+        error_message: 'There are not enough words in this lesson to generate a practice'
+      }]
+    end
     questions_attributes = []
     words = lesson.wordinfos.map(&:word)
     lesson.wordinfos.each do |wordinfo|
+      if wordinfo.definition.blank?
+        return [{ error_message: "#{wordinfo.word} does not have a definition" }]
+      end
       correct_option = wordinfo.word
       incorrect_options = (words - [correct_option]).sample(3)
       questions_attributes << {
@@ -150,21 +176,31 @@ class PracticesController < ApplicationController
   end
 
   def generate_synonym_questions(lesson)
-    return nil if lesson.wordinfos.length < 4
+    if lesson.wordinfos.length < 4
+      return [{
+        error_message: 'There are not enough words in this lesson to generate a practice'
+      }]
+    end
     questions_attributes = []
     synonyms = []
     lesson.wordinfos.map { |wordinfo| synonyms += wordinfo.synonyms.map(&:word) }
     lesson.wordinfos.each do |wordinfo|
       correct_options = wordinfo.synonyms.map(&:word)
-      incorrect_options = (synonyms - correct_options).sample(3)
+      incorrect_options = (synonyms - correct_options)
+      if correct_options.empty? || incorrect_options.length < 3
+        return [{
+          error_message: 'There are not enough synonyms in this lesson to generate a practice'
+        }]
+      end
+      random_incorrect = incorrect_options.sample(3)
       questions_attributes << {
         type: 'mc',
         prompts_attributes: [{ text: "What is a synonym of #{wordinfo.word}?" }],
         options_attributes: [
           { value: correct_options[0], is_correct: true },
-          { value: incorrect_options[0], is_correct: false },
-          { value: incorrect_options[1], is_correct: false },
-          { value: incorrect_options[2], is_correct: false }
+          { value: random_incorrect[0], is_correct: false },
+          { value: random_incorrect[1], is_correct: false },
+          { value: random_incorrect[2], is_correct: false }
         ]
       }
     end

--- a/test/controllers/practices_controller_test.rb
+++ b/test/controllers/practices_controller_test.rb
@@ -70,6 +70,24 @@ class PracticesControllerTest < ActionController::TestCase
     assert_json_match({ errors: { type: ['\'a\' is not a valid type'] } }, @response.body)
   end
 
+  test 'POST /api/lesson/:id/practice/ can\'t generate same practice twice' do
+    login_as_testuser
+    post :create, params: { id: lessons(:english101).id, type: 'synonym' }
+    assert_response :bad_request
+    error_response = { errors: { type: ['has already been taken'] } }
+    assert_json_match error_response, @response.body
+  end
+
+  test 'POST /api/lesson/:id/practice/ can\'t generate sentence practice without sentence' do
+    login_as_testuser
+    lessons(:english101).wordinfos.first.sentences.first.destroy
+    post :create, params: { id: lessons(:english101).id, type: 'sentence' }
+    assert_response :conflict
+    error_message = 'probably does not have any context sentences'
+    error_response = { errors: [error_message], error_message: error_message }
+    assert_json_match error_response, @response.body
+  end
+
   test 'POST /api/lesson/:id/practice/ generate sentence Q\'s with 1 word in lesson' do
     login_as_testuser
     post :create, params: { id: lessons(:english101).id, type: 'sentence' }
@@ -87,20 +105,61 @@ class PracticesControllerTest < ActionController::TestCase
     assert_json_match practice, @response.body
   end
 
+  test 'POST /api/lesson/:id/practice/ can\'t generate definition practice without definition' do
+    login_as_testuser
+    controller = @controller
+    @controller = LessonsController.new
+    post :create
+    lesson_id = JSON.parse(@response.body)['id']
+    lesson = { id: lesson_id, wordinfos:
+      [{ word: 'hat' },
+       { word: 'plate', definition: 'eat dinner from' },
+       { word: 'screen', definition: 'watch a tv show' },
+       { word: 'pan', definition: 'cook in' }] }
+    patch :update, params: { id: lesson_id, lesson: lesson, type: 'definition' }, as: :json
+    @controller = controller
+    post :create, params: { id: lesson_id }
+    assert_response :conflict
+    error_message = 'hat does not have a definition'
+    error_response = { errors: [error_message], error_message: error_message }
+    assert_json_match error_response, @response.body
+  end
+
+  test 'POST /api/lesson/:id/practice/ can\'t generate synonym practice without enough synonyms' do
+    login_as_testuser
+    controller = @controller
+    @controller = LessonsController.new
+    post :create
+    lesson_id = JSON.parse(@response.body)['id']
+    lesson = { id: lesson_id, wordinfos:
+      [{ word: 'hat' },
+       { word: 'plate', synonyms: ['dish'] },
+       { word: 'screen', synonyms: ['monitor'] },
+       { word: 'pan', synonyms: ['pot'] }] }
+    patch :update, params: { id: lesson_id, lesson: lesson, type: 'synonym' }, as: :json
+    @controller = controller
+    post :create, params: { id: lesson_id }
+    assert_response :conflict
+    error_message = 'There are not enough synonyms in this lesson to generate a practice'
+    error_response = { errors: [error_message], error_message: error_message }
+    assert_json_match error_response, @response.body
+  end
+
   test 'POST /api/lesson/:id/practice/ can\'t generate definition Q\'s with 1 word in lesson' do
     login_as_testuser
     post :create, params: { id: lessons(:english101).id, type: 'definition' }
     assert_response :conflict
-    error_message = 'There are not enough words in this practice to generate a practice'
+    error_message = 'There are not enough words in this lesson to generate a practice'
     error_response = { errors: [error_message], error_message: error_message }
     assert_json_match error_response, @response.body
   end
 
   test 'POST /api/lesson/:id/practice/ can\'t generate synonym Q\'s with 1 word in lesson' do
     login_as_testuser
+    practices(:synonym_mc).destroy
     post :create, params: { id: lessons(:english101).id, type: 'synonym' }
     assert_response :conflict
-    error_message = 'There are not enough words in this practice to generate a practice'
+    error_message = 'There are not enough words in this lesson to generate a practice'
     error_response = { errors: [error_message], error_message: error_message }
     assert_json_match error_response, @response.body
   end


### PR DESCRIPTION
Related Issue #167 

Changes:
- Rollback practice create if there's any errors in question generation
- Catch duplicate practice error
- Add question generation errors:
  - If a wordinfo doesn't have a context sentence
  - If a wordinfo doesn't have a definition
  - If a wordinfo doesn't have a synonym
  - If there aren't at least three other synonyms in the lesson
- Added tests