### PR TITLE
Change sentences to array of strings and move validation

### DIFF
--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -10,7 +10,7 @@ class LessonsController < ApplicationController
   #     forms: [{ word: '', part_of_speech: '' }],
   #     synonyms: [''],
   #     antonyms: [''],
-  #     sentences: [{ context_sentence: '' }]
+  #     sentences: ['']
   #   } }] }
   before_action :signed_in?
   before_action :correct_user?, only: [:update, :destroy]
@@ -143,7 +143,7 @@ class LessonsController < ApplicationController
       info[:forms_attributes] = info[:forms]
       info[:synonyms_attributes] = (info[:synonyms] || []).map { |s| { word: s } }
       info[:antonyms_attributes] = (info[:antonyms] || []).map { |s| { word: s } }
-      info[:sentences_attributes] = info[:sentences]
+      info[:sentences_attributes] = (info[:sentences] || []).map { |s| { context_sentence: s } }
     end
     params.require(:lesson).permit(
       :id,
@@ -169,16 +169,16 @@ class LessonsController < ApplicationController
     wordinfos_uniq = wordinfos.uniq! { |wordinfo| wordinfo['word'].downcase }
     errors['wordinfos.word'] = ['has already been taken'] unless wordinfos_uniq.nil?
     wordinfos.each do |wordinfo|
-      errors = check_duplicates_wordinfo_nested wordinfo, 'roots', 'root', errors
-      errors = check_duplicates_wordinfo_nested wordinfo, 'forms', 'word', errors
-      errors = check_duplicates_wordinfo_nested wordinfo, 'synonyms', 'word', errors, false
-      errors = check_duplicates_wordinfo_nested wordinfo, 'antonyms', 'word', errors, false
-      errors = check_duplicates_wordinfo_nested wordinfo, 'sentences', 'context_sentence', errors
+      errors = check_duplicate_attributes wordinfo, 'roots', 'root', errors
+      errors = check_duplicate_attributes wordinfo, 'forms', 'word', errors
+      errors = check_duplicate_attributes wordinfo, 'synonyms', 'word', errors, false
+      errors = check_duplicate_attributes wordinfo, 'antonyms', 'word', errors, false
+      errors = check_duplicate_attributes wordinfo, 'sentences', 'context_sentence', errors, false
     end
     errors
   end
 
-  def check_duplicates_wordinfo_nested(wordinfo, model, attribute, errors, index = true)
+  def check_duplicate_attributes(wordinfo, model, attribute, errors, index = true)
     extractor = !index ? proc { |m| m.downcase } : proc { |m| m[attribute].downcase }
     if wordinfo[model] && !wordinfo[model].uniq!(&extractor).nil?
       errors["wordinfos.#{model}.#{attribute}"] = ['has already been taken']

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -137,6 +137,9 @@ class PracticesController < ApplicationController
       words << wordinfo.word
       answer = ''
       words.each { |word| answer = word if sentence.include? word }
+      if answer == ''
+        return [{ error_message: "#{wordinfo.word} has an invalid context sentence" }]
+      end
       sentence.sub!(answer, '__________') # replace answer with underscores
       questions_attributes << {
         type: 'fitb',

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -31,6 +31,7 @@ class Lesson < ApplicationRecord
     lesson&.[]('wordinfos')&.each do |wordinfo|
       wordinfo['synonyms'].map! { |synonym| synonym['word'] }
       wordinfo['antonyms'].map! { |antonym| antonym['word'] }
+      wordinfo['sentences'].map! { |sentence| sentence['context_sentence'] }
     end
     lesson&.[]('practices')&.map! { |practice| practice['id'] }
     lesson

--- a/app/models/sentence.rb
+++ b/app/models/sentence.rb
@@ -2,15 +2,4 @@ class Sentence < ApplicationRecord
   belongs_to :wordinfo
   validates :context_sentence, presence: true
   validates_uniqueness_of :context_sentence, scope: :wordinfo, case_sensitive: false
-  validate :sentence_contains_word_or_form
-
-  private
-
-  def sentence_contains_word_or_form
-    words = []
-    words = wordinfo.forms.map(&:word) if wordinfo
-    words << wordinfo.word if wordinfo
-    return if words.any? { |word| context_sentence.include? word }
-    errors.add(:context_sentence, 'doesn\'t contain the word or a form')
-  end
 end

--- a/app/models/wordinfo.rb
+++ b/app/models/wordinfo.rb
@@ -30,6 +30,7 @@ class Wordinfo < ApplicationRecord
       end
     wordinfos&.[]('synonyms')&.map! { |synonym| synonym['word'] }
     wordinfos&.[]('antonyms')&.map! { |antonym| antonym['word'] }
+    wordinfos&.[]('sentences')&.map! { |sentence| sentence['context_sentence'] }
     wordinfos
   end
 end

--- a/test/controllers/practices_controller_test.rb
+++ b/test/controllers/practices_controller_test.rb
@@ -96,6 +96,16 @@ class PracticesControllerTest < ActionController::TestCase
     assert_json_match error_response, @response.body
   end
 
+  test 'POST /api/lesson/:id/practice/ can\'t generate sentence practice with invalid sentence' do
+    login_as_testuser
+    lessons(:english101).wordinfos.first.sentences.first.update(context_sentence: 'Test sentence')
+    post :create, params: { id: lessons(:english101).id, type: 'sentence' }
+    assert_response :conflict
+    error_message = 'probably has an invalid context sentence'
+    error_response = { errors: [error_message], error_message: error_message }
+    assert_json_match error_response, @response.body
+  end
+
   test 'POST /api/lesson/:id/practice/ generate sentence Q\'s with 1 word in lesson' do
     login_as_testuser
     post :create, params: { id: lessons(:english101).id, type: 'sentence' }

--- a/test/models/sentence_test.rb
+++ b/test/models/sentence_test.rb
@@ -11,13 +11,4 @@ class SentenceTest < ActiveSupport::TestCase
     )
     assert_includes sentence.errors.full_messages, 'Context sentence has already been taken'
   end
-
-  test 'validates sentence contains word or form' do
-    sentence = Sentence.create(
-      context_sentence: 'Test',
-      wordinfo: wordinfos(:probably)
-    )
-    assert_includes sentence.errors.full_messages,
-                    'Context sentence doesn\'t contain the word or a form'
-  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -45,7 +45,7 @@ module ActiveSupport
             forms: [{ word: 'probable', part_of_speech: '' }],
             synonyms: ['likely'],
             antonyms: ['unlikely'],
-            sentences: [{ context_sentence: 'This is probably the best test ever' }]
+            sentences: ['This is probably the best test ever']
           }
         ],
         practices: [907223594]


### PR DESCRIPTION
Related Issue #204 and #205 

Changes:
- Wordinfo sentences changed to array of strings
- Move validation that sentence contains a word from sentence model to practice generation