### PR TITLE
Load only lesson summaries when we fetch all

### DIFF
--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -11,7 +11,8 @@ class LessonsController < ApplicationController
   #     synonyms: [''],
   #     antonyms: [''],
   #     sentences: ['']
-  #   } }] }
+  #   } }],
+  #   practices: [int] }
   before_action :signed_in?
   before_action :correct_user?, only: [:update, :destroy]
 
@@ -21,12 +22,13 @@ class LessonsController < ApplicationController
   #   none
   # Success response:
   #   Code: 200
-  #   Content: [{ lesson }]
+  #   Content: [{ id: int, title: '' }]
   # Error response:
   #   Code: 401
   #   Content: { errors: ['Unauthorized'], error_message: 'Unauthorized' }
   def index
     render json: Lesson.where(owner_id: session[:user_id][:value])
+      .as_json(except: [:owner_id, :created_at, :updated_at])
   end
 
   # POST /api/lesson

--- a/client/src/actions/lesson.ts
+++ b/client/src/actions/lesson.ts
@@ -5,6 +5,7 @@ import {
 } from './util';
 import { push } from 'react-router-redux';
 import { Lesson } from '../reducers/lessonReducer';
+import { LessonSummary } from '../reducers/lessonSummaryReducer';
 
 export interface CreateLessonPending {
     type: 'create_lesson_pending';
@@ -27,18 +28,17 @@ const headers = {
 export function loadLessons() {
     return (dispatch: any) => {
         dispatch({
-            type: 'load_lessons_pending'
+            type: 'load_lesson_summaries_pending'
         });
         fetch('/api/lesson', {
             headers,
             credentials: 'same-origin'
         })
         .then(errorCheck)
-        .then((res: any[]) => {
-            res.forEach(l => l.wordinfos.forEach((w: any) => w.id = undefined));
+        .then((res: LessonSummary[]) => {
             dispatch({
-                type: 'load_all_lesssons_success',
-                lessons: res as Lesson[]
+                type: 'load_lesson_summaries_success',
+                lessonSummaries: res
             });
         })
         .catch((err: Error) => {

--- a/client/src/components/Home.tsx
+++ b/client/src/components/Home.tsx
@@ -6,12 +6,12 @@ import {
 } from 'material-ui';
 
 import ContentAdd from 'material-ui/svg-icons/content/add';
-import {Lesson} from '../reducers/lessonReducer';
+import {LessonSummary} from '../reducers/lessonSummaryReducer';
 import Page from './util/Page';
 import * as React from 'react';
 
 export interface HomeProps {
-    lessons?: Lesson[];
+    lessons?: LessonSummary[];
     onCreateLessonClick?: () => void;
     onClickLesson?: (id: number) => void;
 }

--- a/client/src/containers/HomeContainer.tsx
+++ b/client/src/containers/HomeContainer.tsx
@@ -6,7 +6,7 @@ import { push } from 'react-router-redux';
 
 function mapStateToProps(state: State): HomeProps {
     return {
-        lessons: Object.keys(state.lesson).map((idx: any) => state.lesson[idx])
+        lessons: Object.keys(state.lessonSummary).map((idx: any) => state.lessonSummary[idx])
     };
 }
 

--- a/client/src/reducers/index.ts
+++ b/client/src/reducers/index.ts
@@ -1,5 +1,6 @@
 import { SessionState, sessionReducer } from './sessionReducer';
 import { LessonState, lessonReducer } from './lessonReducer';
+import { LessonSummaryState, lessonSummaryReducer } from './lessonSummaryReducer';
 import { RegistrationState, registrationReducer } from './registrationReducer';
 import { PracticeState, practiceReducer } from './practiceReducer';
 import { ErrorState, errorReducer } from './errorReducer';
@@ -12,6 +13,7 @@ export interface State {
     registration: RegistrationState;
     routing: any;
     lesson: LessonState;
+    lessonSummary: LessonSummaryState;
     practice: PracticeState;
 }
 
@@ -21,5 +23,6 @@ export const app = combineReducers({
     registration: registrationReducer,
     routing: routerReducer,
     lesson: lessonReducer,
+    lessonSummary: lessonSummaryReducer,
     practice: practiceReducer
 });

--- a/client/src/reducers/lessonSummaryReducer.ts
+++ b/client/src/reducers/lessonSummaryReducer.ts
@@ -1,0 +1,25 @@
+export interface LessonSummary {
+    id: number;
+    title: string;
+}
+
+export type LessonSummaryState = {[id: number]: LessonSummary};
+
+export const lessonSummaryReducer = (state: LessonSummaryState, action: any): LessonSummaryState => {
+    if (state === undefined) return {};
+    switch (action.type) {
+        case 'save_lesson_local':
+        case 'create_lesson_success':
+            return {...state,
+                [action.lesson.id]: action.lesson.title
+            };
+        case 'load_lesson_summaries_success':
+            let newState = {...state};
+            action.lessonSummaries.forEach(
+                (summ: LessonSummary) => newState[summ.id] = summ
+            );
+            return newState;
+        default:
+            return state;
+    }
+};

--- a/test/controllers/lessons_controller_test.rb
+++ b/test/controllers/lessons_controller_test.rb
@@ -12,7 +12,10 @@ class LessonsControllerTest < ActionController::TestCase
     login_as_testuser
     get :index
     assert_response :ok
-    assert_json_match [lesson_pattern], @response.body
+    pattern = lesson_pattern
+    pattern.delete(:wordinfos)
+    pattern.delete(:practices)
+    assert_json_match [pattern], @response.body
   end
 
   test 'GET /api/lesson/:id unauthorized' do


### PR DESCRIPTION
This change contains the front-end and backend change to implement this.

We do this by establishing a new reducer to store the lesson "summaries" (word chosen to allow for expanded information in the future.

This store is updated when full lessons are edited.