### PR TITLE
Add course_ids to lessons

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -87,7 +87,7 @@ class CoursesController < ApplicationController
   #   none
   # Success response:
   #   Code: 200
-  #   Content: [{ id: int, title: '' }]
+  #   Content: [{ id: int, title: '', course_ids: [int] }]
   # Error response:
   #   (1) Code: 401
   #   Content: { errors: ['Unauthorized'], error_message: 'Unauthorized' }
@@ -104,7 +104,7 @@ class CoursesController < ApplicationController
   #   lesson_id (int)
   # Success response:
   #   Code: 200
-  #   Content: [{ id: int, title: '' }]
+  #   Content: [{ id: int, title: '', course_ids: [int] }]
   # Error response:
   #   (1) Code: 401
   #   Content: { errors: ['Unauthorized'], error_message: 'Unauthorized' }
@@ -142,7 +142,7 @@ class CoursesController < ApplicationController
   #   none
   # Success response:
   #   Code: 200
-  #   Content: [{ id: int, title: '' }]
+  #   Content: [{ id: int, title: '', course_ids: [int] }]
   # Error response:
   #   (1) Code: 401
   #   Content: { errors: ['Unauthorized'], error_message: 'Unauthorized' }

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -1,6 +1,7 @@
 class LessonsController < ApplicationController
   # { lesson } = {
   #   id: int,
+  #   course_ids: [int],
   #   title: '',
   #   wordinfos: [{
   #     word: '',
@@ -22,7 +23,7 @@ class LessonsController < ApplicationController
   #   none
   # Success response:
   #   Code: 200
-  #   Content: [{ id: int, title: '' }]
+  #   Content: [{ id: int, title: '', course_ids: [int] }]
   # Error response:
   #   Code: 401
   #   Content: { errors: ['Unauthorized'], error_message: 'Unauthorized' }

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -34,6 +34,7 @@ class Lesson < ApplicationRecord
       wordinfo['sentences'].map! { |sentence| sentence['context_sentence'] }
     end
     lesson&.[]('practices')&.map! { |practice| practice['id'] }
+    lesson['course_ids'] = course_ids
     lesson
   end
 end

--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -107,7 +107,7 @@ class CoursesControllerTest < ActionController::TestCase
     login_as_testuser
     get :lessons, params: { id: courses(:testcourse).id }
     assert_response :ok
-    pattern = [{ id: 318230600, title: 'English 101' }]
+    pattern = [{ id: 318230600, title: 'English 101', course_ids: [393749808] }]
     assert_json_match pattern, @response.body
   end
 
@@ -171,7 +171,8 @@ class CoursesControllerTest < ActionController::TestCase
     @controller = controller
     patch :add_lesson, params: { id: courses(:testcourse).id, lesson_id: lesson_id }
     assert_response :ok
-    pattern = [{ id: 318230600, title: 'English 101' }, { id: 318230601, title: 'Untitled' }]
+    pattern = [{ id: 318230600, title: 'English 101', course_ids: [393749808] },
+               { id: 318230601, title: 'Untitled', course_ids: [393749808] }]
     assert_json_match pattern, @response.body
   end
 
@@ -212,7 +213,7 @@ class CoursesControllerTest < ActionController::TestCase
     login_as_testuser
     delete :remove_lesson, params: { id: courses(:testcourse).id, l_id: lessons(:english201).id }
     assert_response :ok
-    pattern = [{ id: 318230600, title: 'English 101' }]
+    pattern = [{ id: 318230600, title: 'English 101', course_ids: [393749808] }]
     assert_json_match pattern, @response.body
   end
 

--- a/test/controllers/lessons_controller_test.rb
+++ b/test/controllers/lessons_controller_test.rb
@@ -52,7 +52,7 @@ class LessonsControllerTest < ActionController::TestCase
     login_as_testuser
     post :create
     assert_response :ok
-    pattern = { id: 318230601, title: 'Untitled', wordinfos: [], practices: [] }
+    pattern = { id: 318230601, title: 'Untitled', wordinfos: [], practices: [], course_ids: [] }
     assert_json_match pattern, @response.body
   end
 

--- a/test/models/lesson_test.rb
+++ b/test/models/lesson_test.rb
@@ -15,7 +15,7 @@ class LessonTest < ActiveSupport::TestCase
 
   test 'lesson as json custom options' do
     lesson = lessons(:english101)
-    pattern = { id: 318230600, title: 'English 101' }
+    pattern = { id: 318230600, title: 'English 101', course_ids: [393749808] }
     assert_json_match pattern, lesson.as_json(only: [:id, :title])
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -48,7 +48,8 @@ module ActiveSupport
             sentences: ['This is probably the best test ever']
           }
         ],
-        practices: [907223594]
+        practices: [907223594],
+        course_ids: [393749808]
       }
     end
 


### PR DESCRIPTION
Related Issue #246 

Changes:
- Add `course_ids` to lesson json

The lesson-courses relationship is many to many so it has to be `course_ids: [int]` and not `course_id: int`