### PR TITLE
Filter courses not in a lesson

### DIFF
--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -16,8 +16,10 @@ class LessonsController < ApplicationController
   before_action :signed_in?
   before_action :correct_user?, only: [:update, :destroy]
 
-  # GET /api/lesson
+  # GET /api/lesson?filter=not_in_course
   # Desc: return all lessons created by current user
+  #   If filter query param provided and value is 'not_in_course',
+  #   return only the lessons that aren't in a course
   # Request body params:
   #   none
   # Success response:
@@ -27,8 +29,9 @@ class LessonsController < ApplicationController
   #   Code: 401
   #   Content: { errors: ['Unauthorized'], error_message: 'Unauthorized' }
   def index
-    render json: Lesson.where(owner_id: session[:user_id][:value])
-      .as_json(except: [:owner_id, :created_at, :updated_at])
+    lessons = Lesson.where(owner_id: session[:user_id][:value])
+    lessons = lessons.select { |l| l.courses.empty? } if params[:filter] == 'not_in_course'
+    render json: lessons.as_json(except: [:owner_id, :created_at, :updated_at])
   end
 
   # POST /api/lesson

--- a/test/controllers/lessons_controller_test.rb
+++ b/test/controllers/lessons_controller_test.rb
@@ -18,6 +18,13 @@ class LessonsControllerTest < ActionController::TestCase
     assert_json_match [pattern], @response.body
   end
 
+  test 'GET /api/lesson?filter=not_in_course success' do
+    login_as_testuser
+    get :index, params: { filter: 'not_in_course' }
+    assert_response :ok
+    assert_json_match [], @response.body
+  end
+
   test 'GET /api/lesson/:id unauthorized' do
     get :show, params: { id: lessons(:english101).id }
     assert_response :unauthorized


### PR DESCRIPTION
Related Issue #244 

Changes:
- Add query param on get lessons endpoint to return only lessons that are not in a course `/api/lesson?filter=not_in_course`