### PR TITLE
Maintain focus on rerender

### DIFF
--- a/client/src/components/Drawer.tsx
+++ b/client/src/components/Drawer.tsx
@@ -34,7 +34,7 @@ class DrawerContainer extends React.Component<DrawerProps, {}> {
             this.props.onRequestChange(false, '');
           }
         }} />
-        <Menu>
+        <Menu disableAutoFocus={true}>
           <Subheader>Your Courses</Subheader>
           {courses}
         </Menu>

--- a/client/src/components/Lesson/WordCreator/WordFormSelector.tsx
+++ b/client/src/components/Lesson/WordCreator/WordFormSelector.tsx
@@ -54,18 +54,17 @@ const WordFormSelector = (props: WordFormSelectorProps) => {
             props.onChange(newForms);
         };
 
-        return (<div key={form.word} style={{ display: 'flex' }}>
+        return (<div key={`form-${index}`} style={{ display: 'flex' }}>
             <TextField
-                name={form.word}
-                value={form.word}
-                style={{ width: '65%' }}
+                name={`form-name-${index}`}
+                defaultValue={form.word}
                 onChange={changeHandleInput} />
             <SelectField
                 style={{ width: '30%', marginLeft: '5%' }}
                 value={form.part_of_speech}
                 onChange={changeHandleSelection}>
                 {parts_of_speech.map(part =>
-                    <MenuItem key={part + form.word} value={part} primaryText={part}/>
+                    <MenuItem key={part + `form-${index}`} value={part} primaryText={part}/>
                 )}
             </SelectField>
             <IconButton iconClassName='material-icons'

--- a/client/src/components/Lesson/WordCreator/WordRootSelector.tsx
+++ b/client/src/components/Lesson/WordCreator/WordRootSelector.tsx
@@ -52,7 +52,7 @@ const WordRootSelector = (props: WordRootSelectorProps) => {
             props.onChange(newRoots);
         };
 
-        return (<div key={root.root} style={{ display: 'flex' }}>
+        return (<div key={`root.${index}`} style={{ display: 'flex' }}>
             <TextField
                 name={root.root}
                 value={root.root}


### PR DESCRIPTION
Material UI drawer menu was claiming focus because it's terrible.
Also keys weren't being generated properly in our Selectors
